### PR TITLE
Handle driver camera missing toggle at runtime

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -345,6 +345,11 @@ class Controls:
           self.events.add(EventName.cameraMalfunction)
           if not self.sm.all_alive(['driverCameraState']) and not self.d_camera_hardware_missing:
             self.d_camera_hardware_missing = True
+            IGNORE_PROCESSES.update({"dmonitoringd", "dmonitoringmodeld"})
+            if 'driverCameraState' in self.camera_packets:
+              self.camera_packets.remove('driverCameraState')
+              self.sm.ignore_alive.append('driverCameraState')
+            self.sm.ignore_alive.append('driverMonitoringState')
             self.params.put_bool_nonblocking("DriverCameraHardwareMissing", True)
         elif not self.sm.all_freq_ok(self.camera_packets):
           self.events.add(EventName.cameraFrameRate)

--- a/system/manager/manager.py
+++ b/system/manager/manager.py
@@ -186,6 +186,13 @@ def manager_thread() -> None:
 
     started = sm['deviceState'].started
 
+    if params.get_bool("DriverCameraHardwareMissing"):
+      if "dmonitoringd" not in ignore:
+        ignore += ["dmonitoringd", "dmonitoringmodeld"]
+    else:
+      if "dmonitoringd" in ignore:
+        ignore = [p for p in ignore if p not in ("dmonitoringd", "dmonitoringmodeld")]
+
     if started and not started_prev:
       params.clear_all(ParamKeyType.CLEAR_ON_ONROAD_TRANSITION)
 


### PR DESCRIPTION
## Summary
- dynamically disable driver monitoring processes when the driver camera is missing
- automatically ignore driver camera state when hardware is absent

## Testing
- `pre-commit run --files selfdrive/controls/controlsd.py system/manager/manager.py` *(fails: command not found)*
- `pytest selfdrive/controls/tests/test_fsm.py` *(fails: ModuleNotFoundError: openpilot.common.params_pyx)*

------
https://chatgpt.com/codex/tasks/task_e_68a637bfb940832897a8a38f674a1fd0