### PR TITLE
Handle driver camera and speaker hardware toggles at runtime

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -208,6 +208,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"UpdaterLastFetchTime", PERSISTENT},
     {"Version", PERSISTENT},
     {"DriverCameraHardwareMissing", PERSISTENT},
+    {"SpeakerHardwareMissing", PERSISTENT},
 
     // FrogPilot parameters
     {"AccelerationPath", PERSISTENT | FROGPILOT_STORAGE | FROGPILOT_VISUALS},

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -92,6 +92,10 @@ class Controls:
       IGNORE_PROCESSES.update({"dmonitoringd", "dmonitoringmodeld"})
       self.camera_packets.remove("driverCameraState")
 
+    self.speaker_hardware_missing = self.params.get_bool("SpeakerHardwareMissing")
+    if self.speaker_hardware_missing:
+      IGNORE_PROCESSES.add("soundd")
+
     self.log_sock = messaging.sub_sock('androidLog')
 
     # TODO: de-couple controlsd with card/conflate on carState without introducing controls mismatches
@@ -122,6 +126,11 @@ class Controls:
 
     # detect sound card presence and ensure successful init
     sounds_available = HARDWARE.get_sound_card_online()
+    if not sounds_available and not self.speaker_hardware_missing:
+      self.events.add(EventName.soundsUnavailable)
+      self.params.put_bool_nonblocking("SpeakerHardwareMissing", True)
+      self.speaker_hardware_missing = True
+      IGNORE_PROCESSES.add("soundd")
 
     car_recognized = self.CP.carName != 'mock'
 
@@ -172,8 +181,6 @@ class Controls:
 
     self.startup_event = get_startup_event(car_recognized, not self.CP.passive, len(self.CP.carFw) > 0)
 
-    if not sounds_available:
-      self.events.add(EventName.soundsUnavailable, static=True)
     if not car_recognized:
       self.events.add(EventName.carUnrecognized, static=True)
       if len(self.CP.carFw) > 0:
@@ -334,6 +341,13 @@ class Controls:
     num_events = len(self.events)
 
     not_running = {p.name for p in self.sm['managerState'].processes if not p.running and p.shouldBeRunning}
+    if "soundd" in not_running:
+      if not self.speaker_hardware_missing:
+        self.events.add(EventName.soundsUnavailable)
+        self.params.put_bool_nonblocking("SpeakerHardwareMissing", True)
+        self.speaker_hardware_missing = True
+      IGNORE_PROCESSES.add("soundd")
+      not_running.remove("soundd")
     if self.sm.recv_frame['managerState'] and (not_running - IGNORE_PROCESSES):
       self.events.add(EventName.processNotRunning)
       if not_running != self.not_running_prev:
@@ -345,6 +359,11 @@ class Controls:
           self.events.add(EventName.cameraMalfunction)
           if not self.sm.all_alive(['driverCameraState']) and not self.d_camera_hardware_missing:
             self.d_camera_hardware_missing = True
+            IGNORE_PROCESSES.update({"dmonitoringd", "dmonitoringmodeld"})
+            if 'driverCameraState' in self.camera_packets:
+              self.camera_packets.remove('driverCameraState')
+              self.sm.ignore_alive.append('driverCameraState')
+            self.sm.ignore_alive.append('driverMonitoringState')
             self.params.put_bool_nonblocking("DriverCameraHardwareMissing", True)
         elif not self.sm.all_freq_ok(self.camera_packets):
           self.events.add(EventName.cameraFrameRate)

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -66,6 +66,12 @@ TogglesPanel::TogglesPanel(SettingsWindow *parent) : ListWidget(parent) {
       "../assets/offroad/icon_monitoring.png",
     },
     {
+      "SpeakerHardwareMissing",
+      tr("Speaker Hardware Missing"),
+      tr("Speaker Hardware Missing"),
+      "../assets/offroad/icon_warning.png",
+    },
+    {
       "IsMetric",
       tr("Use Metric System"),
       tr("Display speed in km/h instead of mph."),

--- a/system/manager/manager.py
+++ b/system/manager/manager.py
@@ -167,6 +167,8 @@ def manager_thread() -> None:
   ignore += [x for x in os.getenv("BLOCK", "").split(",") if len(x) > 0]
   if params.get_bool("DriverCameraHardwareMissing"):
     ignore += ["dmonitoringd", "dmonitoringmodeld"]
+  if params.get_bool("SpeakerHardwareMissing"):
+    ignore.append("soundd")
 
   sm = messaging.SubMaster(['deviceState', 'carParams', 'frogpilotPlan'], poll='deviceState')
   pm = messaging.PubMaster(['managerState'])
@@ -185,6 +187,19 @@ def manager_thread() -> None:
     sm.update(1000)
 
     started = sm['deviceState'].started
+
+    if params.get_bool("DriverCameraHardwareMissing"):
+      if "dmonitoringd" not in ignore:
+        ignore += ["dmonitoringd", "dmonitoringmodeld"]
+    else:
+      if "dmonitoringd" in ignore:
+        ignore = [p for p in ignore if p not in ("dmonitoringd", "dmonitoringmodeld")]
+    if params.get_bool("SpeakerHardwareMissing"):
+      if "soundd" not in ignore:
+        ignore.append("soundd")
+    else:
+      if "soundd" in ignore:
+        ignore = [p for p in ignore if p != "soundd"]
 
     if started and not started_prev:
       params.clear_all(ParamKeyType.CLEAR_ON_ONROAD_TRANSITION)


### PR DESCRIPTION
## Summary
- dynamically disable driver monitoring processes when the driver camera is missing
- automatically ignore driver camera state when hardware is absent
- add runtime toggle to disable sound output when speaker hardware is missing

## Testing
- `pre-commit run --files selfdrive/controls/controlsd.py system/manager/manager.py selfdrive/ui/qt/offroad/settings.cc common/params.cc` *(fails: command not found)*
- `pytest selfdrive/controls/tests/test_fsm.py` *(fails: pyenv: version `3.11.4` is not installed, pytest command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a637bfb940832897a8a38f674a1fd0